### PR TITLE
Turn off jsx/react-no-bind errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-config-techchange",
-  "version": "0.0.2",
-  "description": "TechChange's default ESLint configuration for ES2015.",
+  "version": "0.0.3",
+  "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -18,18 +18,22 @@
   "author": {
     "name": "Will Chester",
     "email": "will@techchange.org",
-    "url": "techchange"
+    "url": "techchange.org"
   },
   "contributors": [
     {
       "name": "Will Chester",
       "email": "will@techchange.org",
-      "url": "techchange"
+      "url": "techchange.org"
     },
     {
       "name": "Matthew Heck",
       "email": "matthew@techchange.org",
       "url": "techchange.org"
+    },
+    {
+      "name": "Gabe Isman",
+      "email": "gabe.isman@gmail.com"
     }
   ],
   "license": "MIT",

--- a/rules/react.js
+++ b/rules/react.js
@@ -28,10 +28,9 @@ module.exports = {
 		"react/jsx-max-props-per-line":[2, {
 			"maximum": 1
 		}],
-		// Don't allow .bind or arrow functions in props, unless it's a ref
-		"react/jsx-no-bind": [2, {
-			"ignoreRefs": true
-		}],
+		// Allow arrow functions and binding because "premature optimization is the root of all evil"
+		// or at least because it messes with HMR. (h/t Donald Knuth via Gabe Isman)
+		"react/jsx-no-bind": 0,
 		// Don't allow duplicate props in the same component
 		"react/jsx-no-duplicate-props": 2,
 		// Don't allow unwrapped strings


### PR DESCRIPTION
Although arrow functions and binding inside rendering is bad for performance in React, not doing so prevents hot module reloading from working.

If at some point performance becomes a bigger issue, we can turn this on. But not now.

"premature optimization is the root of all evil"