### PR TITLE
Update ESLint rules based on feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techchange",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "repository": {

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -4,8 +4,8 @@ module.exports = {
 		"accessor-pairs": 2,
 		// Disallow var reference outside of scope
 		"block-scoped-var": 2,
-		// Limit the paths through a function to three at max
-		"complexity": [2, 3],
+		// Limit the paths through a function to five at max
+		"complexity": [1, 5],
 		// Ensure that the type of returns is consistent (i.e. boolean, object, etc)
 		"consistent-return": 2,
 		// Always require curly braces

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -2,7 +2,7 @@ module.exports = {
 	"rules": {
 		// DISABLED UNTIL MORE FLEXIBLE:
 		// Require braces around arrow body when required
-		//"arrow-body-style": [2, "as-needed"],
+		"arrow-body-style": [0, "as-needed"],
 		// Require parens around arrow-functions
 		"arrow-parens": [2, "always"],
 		// Require spaces before and after arrow-function declarations

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -1,7 +1,8 @@
 module.exports = {
 	"rules": {
+		// DISABLED UNTIL MORE FLEXIBLE:
 		// Require braces around arrow body when required
-		"arrow-body-style": [2, "as-needed"],
+		//"arrow-body-style": [2, "as-needed"],
 		// Require parens around arrow-functions
 		"arrow-parens": [2, "always"],
 		// Require spaces before and after arrow-function declarations

--- a/rules/node.js
+++ b/rules/node.js
@@ -3,7 +3,7 @@ module.exports = {
 		// Require return with callback when multiple callbacks included in a function
 		"callback-return": 2,
 		// Require require() statements to be at the top-level of module scope
-		"global-require": 2,
+		"global-require": 1,
 		// Require error handling in callbacks using the "err or error" argument
 		"handle-callback-err": [2, "^(err|error)$"],
 		// Warn if require() variables are declared with other non-require() variables

--- a/rules/react.js
+++ b/rules/react.js
@@ -64,7 +64,7 @@ module.exports = {
 		"react/no-is-mounted": 2,
 		// DISABLING, THERE ARE TIMES WHEN THIS SHOULD BE ALLOWED
 		// Only allow one component to be defined per file.
-		//"react/no-multi-comp": 2,
+		"react/no-multi-comp": 0,
 		// Allow local state to be changed, even though we're using Redux.
 		"react/no-set-state": 0,
 		// Don't allow string references.

--- a/rules/react.js
+++ b/rules/react.js
@@ -62,8 +62,9 @@ module.exports = {
 		"react/no-direct-mutation-state": 2,
 		// Don't allow "isMounted()" calls.
 		"react/no-is-mounted": 2,
+		// DISABLING, THERE ARE TIMES WHEN THIS SHOULD BE ALLOWED
 		// Only allow one component to be defined per file.
-		"react/no-multi-comp": 2,
+		//"react/no-multi-comp": 2,
 		// Allow local state to be changed, even though we're using Redux.
 		"react/no-set-state": 0,
 		// Don't allow string references.

--- a/rules/style.js
+++ b/rules/style.js
@@ -49,7 +49,7 @@ module.exports = {
 		// Enforces maximum nesting level, need to check with team if we want to enforce this
 		"max-depth": [1, 5],
 		// Enforce a maximum line length of 100 characters, while treating tabs as 2 characters
-		"max-len": [2, 100, 2],
+		"max-len": [1, 100, 2],
 		// Enforce a maximum of 10 levels of nested callbacks
 		"max-nested-callbacks": 2,
 		// Enforce a maximum of 5 arguments a function can accept


### PR DESCRIPTION
@gabeisman has pointed out a number of rules that are causing numerous ESLint errors. This PR updates some of these so that they are warnings and comments out others until ESLint gets smarter about recognizing nuanced applications of some of the rules. One impetus for these changes is the fact that we are now going to be linting as part of our CI suite and any errors will cause the CI to fail.

Specifically, the following rules have been reduced to warnings:
* Max Lenth - We should be mindful of this, but not worth preventing the CI from passing.
* Complexity - There are times when complexity is unavoidable. Keeping as an error, but could certainly be convinced that this should be removed in favor of convention rather than enforcement
* Global Require - With react-router this is unavoidable, but should be fixed in ESLint 2.0. Making this a warning until we get to ESLint 2.0+

The following rules have been commented out until we decide to remove or otherwise adjust:
* No Multi Component - The ESLint React plugin does not differentiate between multiple dumb components in one file. There are times when this can be useful, so removing for now.
* Arrow Body Style - There is no way currently to differentiate between instances where it is convenient to leave out surrounding braces. This will be enforced via convention rather than linting

These are only suggested changes, so feel free to push back on anything in here. Or add others that you'd like to update.