### PR TITLE
Update for eslint2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Extend your `.eslintrc` file as follows.
 }
 ```
 
+_Note: This module requires eslint >= 2.0.0, eslint-loader >= 1.3.0, and eslint-babel >= 5.0.0 as of version 0.1.0._
+
 Enjoy!
 
 ### React Installation
@@ -38,7 +40,3 @@ Second, when you extend the `.estlintrc` file, you will have to suffic the exten
 	"extends": "eslint-config-techchange/react"
 }
 ```
-
-## Future plans
-
-We will follow semantic versioning for this starting at v0.1.0.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 module.exports = {
 	"parser": "babel-eslint",
+	"parser-options": {
+		"ecmaVersion": 6,
+		"ecmaFeatures": {
+			"impliedStrict": true
+		}
+	},
 	"env": {
 		"node": true,
 		"mocha": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techchange",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techchange",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "repository": {

--- a/react.js
+++ b/react.js
@@ -1,13 +1,17 @@
 module.exports = {
 	"parser": "babel-eslint",
+	"parser-options": {
+		"ecmaVersion": 6,
+		"ecmaFeatures": {
+			"impliedStrict": true,
+			"jsx": true
+		}
+	},
 	"env": {
 		"node": true,
 		"mocha": true,
 		"browser": true,
 		"es6": true
-	},
-	"ecmaFeatures": {
-		"jsx": true
 	},
 	"settings": {
 		"ecmascript": 6,

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -10,8 +10,8 @@ module.exports = {
 		"constructor-super": 2,
 		// Enforce space before generator *, no space after (e.g. function *generator() {})
 		"generator-star-spacing": 2,
-		// Disallow arrow functions where a condition is expected
-		"no-arrow-condition": 2,
+		// Disallow arrow functions where the could be confused with comparison
+		"no-confusing-arrow": 2,
 		// Disallow modifying variables named as class declarations
 		"no-class-assign": 2,
 		// Disallow modifying variables declared as constants

--- a/rules/style.js
+++ b/rules/style.js
@@ -38,6 +38,11 @@ module.exports = {
 			"beforeColon": false,
 			"afterColon": true
 		}],
+		// Enforce spacing before and after keywords
+		"keyword-spacing": [2,{
+			"before": true,
+			"after": true
+		}],
 		// Enforce unix-style line endings
 		"linebreak-style": [2, "unix"],
 		// Enforce spaces before comment blocks and allow comments at the beginning of array and object declarations
@@ -112,20 +117,14 @@ module.exports = {
 		"semi-spacing": 2,
 		// Require semicolons after each new line
 		"semi": [2, "always"],
-		// Require spaces after keywords (e.g. if, else, while, for, etc)
-		"space-after-keywords": 2,
 		// Require space before blocks (e.g. if (a) {})
 		"space-before-blocks": 2,
 		// Disallow space before opening paren in function definitions
 		"space-before-function-paren": [2, "never"],
-		// Disallow space before keywords (if, else, while, for, do, switch, try, catch, function, etc)
-		"space-before-keywords": 2,
 		// Disallow spaces in parens
 		"space-in-parens": 2,
 		// Require space around infix operators (e.g. var foo = 1 + 2, not var foo = 1+2)
 		"space-infix-ops": 2,
-		// Require space after return, throw, and case
-		"space-return-throw-case": 2,
 		// Require spaces around unary words like void, new, delete, disallow around nonwords like ++, --, !
 		"space-unary-ops": 2,
 		// Require spaces in comments (e.g. // This is a comment, not //This is a comment)


### PR DESCRIPTION
- Change deprecated rules and updates some settings according to upgrade guide
- Requires updates of eslint to v2, babel-eslint to v5, and babel-loader to v1.3 for use in projects