### PR TITLE
Update display-name syntax for eslint-react v4.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techchange",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "repository": {

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,7 +1,7 @@
 module.exports = {
 	"rules": {
 		// Don't allow displayName parameters, but require the component to be named by reference.
-		"react/display-name": 2,
+		"react/display-name": 0,
 		// Allow all prop types at this time.
 		"react/forbid-prop-types": 0,
 		// Enforce boolean attributes notation No need for <Component variable={true} />.

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,9 +1,7 @@
 module.exports = {
 	"rules": {
 		// Don't allow displayName parameters, but require the component to be named by reference.
-		"react/display-name": [2, {
-			"acceptTranspilerName": true
-		}],
+		"react/display-name": 2,
 		// Allow all prop types at this time.
 		"react/forbid-prop-types": 0,
 		// Enforce boolean attributes notation No need for <Component variable={true} />.


### PR DESCRIPTION
In v4.0+ display name accepts the transpiled name by default. The `acceptTranspiledName` property is now depreciated in favor of an option to ignore the transpiled name. Without this update, using `eslint-plugin-react` v4+ throws an error.

Unfortunately, the behavior of this option has changed enough that I suggest we now simply turn it off. Before the config allowed the use of the transpiled name only, now we must explicitly define a `displayName` or else eslint throws an error.
