### PR TITLE
Eslint React Rules Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techchange",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "repository": {
@@ -43,6 +43,6 @@
   "homepage": "https://github.com/techchange/eslint-config#readme",
   "peerDependencies": {
     "eslint": "^3.19.0",
-    "eslint-plugin-react": "7.0.0"
+    "eslint-plugin-react": "~7.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,9 @@
   "bugs": {
     "url": "https://github.com/techchange/eslint-config/issues"
   },
-  "homepage": "https://github.com/techchange/eslint-config#readme"
+  "homepage": "https://github.com/techchange/eslint-config#readme",
+  "peerDependencies": {
+    "eslint": "^3.19.0",
+    "eslint-plugin-react": "7.0.0"
+  }
 }

--- a/react.js
+++ b/react.js
@@ -17,7 +17,8 @@ module.exports = {
 		"ecmascript": 6,
 		"jsx": true,
 		"react": {
-			"pragma": "React"
+			"pragma": "React",
+			"version": "15.0"
 		}
 	},
 	"plugins": [

--- a/rules/react.js
+++ b/rules/react.js
@@ -28,7 +28,7 @@ module.exports = {
 			"extensions": [".js", ".jsx"]
 		}],
 		// The first prop of a component should never be on a new line.
-		"react/jsx-first-prop-new-line": ["error", "never"],
+		"react/jsx-first-prop-new-line": ["error", "multiline"],
 		// Ensure correct prefixing of event handlers in JSX.
 		"react/jsx-handler-names": ["warn", {
 			"eventHandlerPrefix": "handle",
@@ -66,6 +66,7 @@ module.exports = {
 		"react/jsx-sort-props": ["error", {
 			"noSortAlphabetically": true,
 			"reservedFirst": true,
+			"shorthandLast": true,
 			"callbacksLast": true,
 		}],
 		// Don't allow a space between / and >. Require a space before self closing.
@@ -104,9 +105,10 @@ module.exports = {
 		"react/no-find-dom-node": "error",
 		// Don't allow "isMounted()" calls.
 		"react/no-is-mounted": "error",
-		// DISABLING, THERE ARE TIMES WHEN THIS SHOULD BE ALLOWED
 		// Only allow one component to be defined per file.
-		"react/no-multi-comp": "off",
+		"react/no-multi-comp": ["error", {
+			"ignoreStateless": true,
+		}],
 		// Don't use the returned element from rendering with ReactDOM.
 		"react/no-render-return-value": "error",
 		// Allow local state to be changed, even though we're using Redux.
@@ -142,7 +144,10 @@ module.exports = {
 		// Don't allow people to forget to return inside render.
 		"react/require-render-return": "error",
 		// Don't allow extra closing tags for components without children.
-		"react/self-closing-comp": "error",
+		"react/self-closing-comp": ["error", {
+			"component": true,
+			"html": false
+		}],
 		// Require a certain organization of methods. Sure! Why not?!
 		// Borrowed from AirBNB. https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react.js#L121
 		"react/sort-comp": ["warn", {

--- a/rules/react.js
+++ b/rules/react.js
@@ -118,7 +118,10 @@ module.exports = {
 		// Don't allow unknown properties.
 		"react/no-unknown-property": "error",
 		// Don't allow proptypes to be defined if they aren't used.
-		"react/no-unused-prop-types": "error",
+		// This is only off because the caveat leads to numerous false positives. Essentially, all
+		// destructured assignments fail:
+		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md#caveats
+		"react/no-unused-prop-types": "off",
 		// Prevent setState in componentDidUpdate
 		"react/no-will-update-set-state": "error",
 		// Only allow ES6 classes.

--- a/rules/react.js
+++ b/rules/react.js
@@ -117,6 +117,8 @@ module.exports = {
 		"react/no-unescaped-entities": "error",
 		// Don't allow unknown properties.
 		"react/no-unknown-property": "error",
+		// Don't allow proptypes to be defined if they aren't used.
+		"react/no-unused-prop-types": "error",
 		// Prevent setState in componentDidUpdate
 		"react/no-will-update-set-state": "error",
 		// Only allow ES6 classes.

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,91 +1,146 @@
 module.exports = {
 	"rules": {
 		// Don't allow displayName parameters, but require the component to be named by reference.
-		"react/display-name": [2, {
-			"acceptTranspilerName": true
+		"react/display-name": ["error", {
+			"ignoreTranspilerName": false
 		}],
 		// Allow all prop types at this time.
-		"react/forbid-prop-types": 0,
+		"react/forbid-component-props": "off",
+		// Allow all element types.
+		"react/forbid-elements": "off",
+		// Don't allow messy imports of other component's prop types.
+		"react/forbid-foreign-prop-types": "error",
+		// Warn if the developer is using vague prop type descriptions, like any, array, and object.
+		"react/forbid-prop-types": "warn",
 		// Enforce boolean attributes notation No need for <Component variable={true} />.
 		// Just do <Component variable />.
-		"react/jsx-boolean-value": [2, "never"],
+		"react/jsx-boolean-value": ["error", "never"],
 		// Require closing brackets to be located immediately following the last prop.
-		"react/jsx-closing-bracket-location": [2, "after-props"],
+		"react/jsx-closing-bracket-location": ["error", "after-props"],
 		// Don't allow spaces between curly braces in JSX attributes.
-		"react/jsx-curly-spacing": [2, "never"],
+		"react/jsx-curly-spacing": ["error", "never", {
+			"allowMultiline": true
+		}],
+		// Don't allow spaces before or after the equal sign for components.
+		"react/jsx-equals-spacing": ["error", "never"],
+		// Allow either .js or .jsx files for components.
+		"react/jsx-filename-extension": ["warn", {
+			"extensions": [".js", ".jsx"]
+		}],
+		// The first prop of a component should never be on a new line.
+		"react/jsx-first-prop-new-line": ["error", "never"],
 		// Ensure correct prefixing of event handlers in JSX.
-		"react/jsx-handler-names": [1, {
+		"react/jsx-handler-names": ["warn", {
 			"eventHandlerPrefix": "handle",
 			"eventHandlerPropPrefix": "on"
 		}],
 		// Require a tab indentation in props.
-		"react/jsx-indent-props": [2, "tab"],
+		"react/jsx-indent-props": ["error", "tab"],
 		// Require tab indentations in all JSX components
-		"react/jsx-indent": [2, "tab"],
+		"react/jsx-indent": ["error", "tab"],
 		// Require key props to be used.
-		"react/jsx-key": 2,
+		"react/jsx-key": "error",
 		// Limit number of props on a single line in JSX to 1
-		"react/jsx-max-props-per-line":[2, {
-			"maximum": 1
+		"react/jsx-max-props-per-line":["error", {
+			"maximum": 1,
+			"when": "always"
 		}],
-		// Allow arrow functions and binding because "premature optimization is the root of all evil"
-		// or at least because it messes with HMR. (h/t Donald Knuth via Gabe Isman)
-		"react/jsx-no-bind": 0,
+		// Require binding to happen in the constructor.
+		"react/jsx-no-bind": ["error", {
+			"allowArrowFunctions": true
+		}],
+		// Don't allow comments inside JSX statements.
+		"react/jsx-no-comment-textnodes": "error",
 		// Don't allow duplicate props in the same component
-		"react/jsx-no-duplicate-props": 2,
+		"react/jsx-no-duplicate-props": "error",
 		// Don't allow unwrapped strings
-		"react/jsx-no-literals": 2,
+		"react/jsx-no-literals": "error",
+		// Don't allow unsafe target=_blanks, must include rel='noreferrer noopener' too.
+		"react/jsx-no-target-blank": "error",
 		// Don't allow undeclared variables in JSX
-		"react/jsx-no-undef": 2,
+		"react/jsx-no-undef": "error",
 		// PascalCase for all components
-		"react/jsx-pascal-case": 2,
-		// Don't require prop types to be sorted in any particular order
-		"react/jsx-sort-prop-types": 0,
-		// Don't require props to be sorted in any particular order.
-		"react/jsx-sort-props": 0,
-		// Allow react to be called and not cause errors.
-		"react/jsx-uses-react": 2,
-		// Allow JSX variables to be marked as used
-		"react/jsx-uses-vars": 2,
-		// Don't allow problematic JSX properties
-		// More here https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md
-		"react/no-danger": 0,
-		// Don't allow deprecated React practices
-		"react/no-deprecated": [2, {
-			"react": "0.14.0"
+		"react/jsx-pascal-case": "error",
+		// Don't require props to be sorted alphabetically, but put reserved props (key, ref) first,
+		// and callbacks last.
+		"react/jsx-sort-props": ["error", {
+			"noSortAlphabetically": true,
+			"reservedFirst": true,
+			"callbacksLast": true,
 		}],
+		// Don't allow a space between / and >. Require a space before self closing.
+		// No space before opening.
+		"react/jsx-tag-spacing": ["error", {
+			"closingSlash": "never",
+			"beforeSelfClosing": "always",
+			"afterOpening": "never"
+		}],
+		// Allow react to be called and not cause errors.
+		"react/jsx-uses-react": "error",
+		// Allow JSX variables to be marked as used
+		"react/jsx-uses-vars": "error",
+		// Require parentheses around miltline JSX statements.
+		"react/jsx-wrap-multilines": "error",
+		// Warn if you're using array indexes as a key. It might be unavoidable, but use a unique id
+		// if possible.
+		"react/no-array-index-key": "warn",
+		// Don't allow somebody to use "children" as a declared prop.
+		"react/no-children-prop": "error",
+		// Don't allow problematic use of children AND dangerouslySetInnerHTML.
+		"react/no-danger-with-children": "error",
+		// Warn on dangerouslySetInnerHTML -- we should always be aware if we're using it.
+		// More here https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md
+		"react/no-danger": "warn",
+		// Don't allow deprecated React methods.
+		"react/no-deprecated": "error",
 		// Prevent setState in componentDidMount
-		"react/no-did-mount-set-state": [2, "allow-in-func"],
+		"react/no-did-mount-set-state": "error",
 		// Prevent setState in componentDidUpdate
-		"react/no-did-update-set-state": [2, "allow-in-func"],
+		"react/no-did-update-set-state": "error",
 		// Don't allow the state to be mutated. Ever.
-		"react/no-direct-mutation-state": 2,
+		"react/no-direct-mutation-state": "error",
+		// Don't allow findDOMNode, prefer using a callback ref instead.
+		// https://github.com/yannickcr/eslint-plugin-react/issues/678#issue-165177220
+		"react/no-find-dom-node": "error",
 		// Don't allow "isMounted()" calls.
-		"react/no-is-mounted": 2,
+		"react/no-is-mounted": "error",
 		// DISABLING, THERE ARE TIMES WHEN THIS SHOULD BE ALLOWED
 		// Only allow one component to be defined per file.
-		"react/no-multi-comp": 0,
+		"react/no-multi-comp": "off",
+		// Don't use the returned element from rendering with ReactDOM.
+		"react/no-render-return-value": "error",
 		// Allow local state to be changed, even though we're using Redux.
-		"react/no-set-state": 0,
+		"react/no-set-state": "off",
 		// Don't allow string references.
-		"react/no-string-refs": 2,
+		"react/no-string-refs": "error",
+		// Don't allow (usually accidentally) unescaped entities from appearing.
+		"react/no-unescaped-entities": "error",
 		// Don't allow unknown properties.
-		"react/no-unknown-property": 2,
+		"react/no-unknown-property": "error",
+		// Prevent setState in componentDidUpdate
+		"react/no-will-update-set-state": "error",
 		// Only allow ES6 classes.
-		"react/prefer-es6-class": [2, "always"],
+		"react/prefer-es6-class": ["error", "always"],
+		// Prefer stateless functions whenever possible.
+		"react/prefer-stateless-function": "error",
 		// Require prop types to be defined.
-		"react/prop-types": 2,
+		"react/prop-types": "error",
 		// Prevent React not being defined when using JSX
-		"react/react-in-jsx-scope": 2,
-		// Only allows .js extensions
-		"react/require-extension": [2, {
-			"extensions": [".js"]
-		}],
+		"react/react-in-jsx-scope": "error",
+		// Don't require defaultProps for props that are not required.
+		// We often use optional props to selectively hide elements in a component if the prop is not
+		// provided, this would be detrimental to that practice.
+		"react/require-default-props": "off",
+		// Don't require optimization -- yet.
+		// This would require every compnent to have a shouldComponentUpdate defined.
+		"react/require-optimization": "off",
+		// Don't allow people to forget to return inside render.
+		"react/require-render-return": "error",
 		// Don't allow extra closing tags for components without children.
-		"react/self-closing-comp": 2,
+		"react/self-closing-comp": "error",
 		// Require a certain organization of methods. Sure! Why not?!
 		// Borrowed from AirBNB. https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react.js#L121
-		"react/sort-comp": [1, {
+		"react/sort-comp": ["warn", {
 			"order": [
 				"lifecycle",
 				"/^on.+$/",
@@ -95,7 +150,11 @@ module.exports = {
 				"render"
 			]
 		}],
-		// Require multiline JSX to be wrapped in parathenticals.
-		"react/wrap-multilines": 2
+		// Don't require sorted prop types, because alphabeticalness is overkill.
+		"react/sort-prop-types": "off",
+		// Require style prop values to be an object.
+		"react/style-prop-object": "error",
+		// Prevent void DOM elements from receiving children.
+		"react/void-dom-elements-no-children": "error",
 	}
 };


### PR DESCRIPTION
This PR allows the newest version of `eslint-plugin-react` to be used with React projects and sets React v0.15 as the target version for all current development. This also changes rule levels from an integer `0`, `1`, `2` set to the string `"off"`, `"warn"`, `"error"` respectively for better semantics.

A number of rule additions are proposed in this PR -- most of these attempt to match already established practices in our projects. A few rules are changed to reflect evolved standards, even if older projects don't meet them. I will highlight a few of the trickier ones in line and welcome any additional perspectives!

To test this and get familiar with what is now problematic, I recommend pulling down this branch, `npm link`ing it, and then seeing what is now considered an error or warning in an existing project. Let me know if you need any help with this!