### PR TITLE
Add j as an exception for id-length rule

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -27,7 +27,7 @@ module.exports = {
 		"func-names": 2,
 		// Enforce a mininmum id length of 2 characters, except i for iterating over loops
 		"id-length": [2, {
-			"exceptions": ["i", "_"]
+			"exceptions": ["i", "_", "j"]
 		}],
 		// Enforce tabs equivalent to two spaces
 		"indent": [2, "tab"],


### PR DESCRIPTION
In the rare event that a nested for loop is needed, I think `j` is a reasonable choice.