### PR TITLE
Fix version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Second, when you extend the `.estlintrc` file, you will have to suffic the exten
 
 ## Changelog
 
-- **0.3.0**
-	- ADDED: Rules for React hooks
+- **1.0.0**
+	- BREAKING: Added rules for React hooks
 - **0.2.0**
 	- UPDATED: Use latest version of `eslint-plugin-react`
 	- ADDED: Additional react rules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-config-techchange",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "lockfileVersion": 1
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-config-techchange",
+  "version": "0.3.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techchange",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Don't want frontend libs to download updates without installing the hook plugin peer dependency first.