### PR TITLE
Eslint rule updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Second, when you extend the `.estlintrc` file, you will have to suffic the exten
 
 ## Changelog
 
+- **2.1.0**
+	- UPDATED: Update `max-len` rule to:
+		- Ignore URLs since these shouldn't have newlines inside them
+		- Ignore internationalization due to long contant names
+	- UPDATED: Increase `complexity` allowed to the eslint default of `20` as existing rule was unnecessarily constraining
+	- UPDATED: Remove react rule to start functions with handle
+	- UPDATED: Update rule `id-length` to allow variables `j` and `k` which are commonly used in `for` loops
 - **2.0.0**
 	- BREAKING: Added jsx-a11y plugin as peer dependency.
 	- ADDED: Added recommended rules from jsx-a11y plugin.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install eslint-plugin-react
 npm install eslint-plugin-react-hooks
 ```
 
-Second, when you extend the `.estlintrc` file, you will have to suffic the extension with `/react`.
+Second, when you extend the `.estlintrc` file, you will have to suffix the extension with `/react`.
 ```json
 {
 	"extends": "eslint-config-techchange/react"
@@ -46,7 +46,8 @@ Second, when you extend the `.estlintrc` file, you will have to suffic the exten
 
 ## Changelog
 
-- **2.1.0**
+- **3.0.0**
+	- BREAKING: Added `react/jsx-indent` rule to enforce tabbing logical expressions inside a JSX statement.
 	- UPDATED: Update `max-len` rule to:
 		- Ignore URLs since these shouldn't have newlines inside them
 		- Ignore internationalization due to long contant names

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-config-techchange",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-config-techchange",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techchange",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techchange",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "repository": {

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -73,7 +73,7 @@ module.exports = {
 		"no-process-env": 1,
 		// Disallow use of depreciated __proto__
 		"no-proto": 2,
-		// Disallow redeclaration of existing variables and global variables
+		// Disallow re-declaration of existing variables and global variables
 		"no-redeclare": [2, {
 			"builtinGlobals": true
 		}],

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -4,8 +4,8 @@ module.exports = {
 		"accessor-pairs": 2,
 		// Disallow var reference outside of scope
 		"block-scoped-var": 2,
-		// Limit the paths through a function to five at max
-		"complexity": [1, 5],
+		// Limit the paths through a function to 20 at max
+		"complexity": [1, 20],
 		// Ensure that the type of returns is consistent (i.e. boolean, object, etc)
 		"consistent-return": 2,
 		// Always require curly braces

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -7,7 +7,7 @@ module.exports = {
 		"arrow-parens": [2, "always"],
 		// Require spaces before and after arrow-function declarations
 		"arrow-spacing": 2,
-		// Require super when necessary, warn when it is used inproperly
+		// Require super when necessary, warn when it is used improperly
 		"constructor-super": 2,
 		// Enforce space before generator *, no space after (e.g. function *generator() {})
 		"generator-star-spacing": 2,

--- a/rules/react.js
+++ b/rules/react.js
@@ -40,6 +40,10 @@ module.exports = {
 			"maximum": 1,
 			"when": "always"
 		}],
+		// Require tabs for logical expressions inside JSX statements.
+		"react/jsx-indent": ["error", "tab", {
+			"indentLogicalExpressions": true
+		}],
 		// Require binding to happen in the constructor.
 		"react/jsx-no-bind": ["error", {
 			"allowArrowFunctions": true

--- a/rules/react.js
+++ b/rules/react.js
@@ -29,11 +29,6 @@ module.exports = {
 		}],
 		// The first prop of a component should never be on a new line.
 		"react/jsx-first-prop-new-line": ["error", "multiline"],
-		// Ensure correct prefixing of event handlers in JSX.
-		"react/jsx-handler-names": ["warn", {
-			"eventHandlerPrefix": "handle",
-			"eventHandlerPropPrefix": "on"
-		}],
 		// Require a tab indentation in props.
 		"react/jsx-indent-props": ["error", "tab"],
 		// Require tab indentations in all JSX components

--- a/rules/react.js
+++ b/rules/react.js
@@ -139,7 +139,7 @@ module.exports = {
 		// provided, this would be detrimental to that practice.
 		"react/require-default-props": "off",
 		// Don't require optimization -- yet.
-		// This would require every compnent to have a shouldComponentUpdate defined.
+		// This would require every component to have a shouldComponentUpdate defined.
 		"react/require-optimization": "off",
 		// Don't allow people to forget to return inside render.
 		"react/require-render-return": "error",

--- a/rules/style.js
+++ b/rules/style.js
@@ -27,7 +27,7 @@ module.exports = {
 		"func-names": 2,
 		// Enforce a minimum id length of 2 characters, except i for iterating over loops
 		"id-length": [2, {
-			"exceptions": ["i", "j", "k", "_"]
+			"exceptions": ["i", "j", "k"]
 		}],
 		// Enforce tabs equivalent to two spaces
 		"indent": [2, "tab"],

--- a/rules/style.js
+++ b/rules/style.js
@@ -27,7 +27,7 @@ module.exports = {
 		"func-names": 2,
 		// Enforce a mininmum id length of 2 characters, except i for iterating over loops
 		"id-length": [2, {
-			"exceptions": ["i", "_"]
+			"exceptions": ["i", "j", "_"]
 		}],
 		// Enforce tabs equivalent to two spaces
 		"indent": [2, "tab"],

--- a/rules/style.js
+++ b/rules/style.js
@@ -1,7 +1,7 @@
 module.exports = {
 	"rules": {
 		// Enforce no spaces at bookends of array/object definitions (e.g. [2, 3] is valid, [ 2, 3 ] is invalid)
-		"array-bracket-spacing": [2, "never"],		
+		"array-bracket-spacing": [2, "never"],
 		// Enforce spaces in single line blocks (e.g. function() { return true; } is valid, function() {return true;} is invalid)
 		"block-spacing": 2,
 		// Enforce consistent brace style
@@ -25,7 +25,7 @@ module.exports = {
 		"eol-last": 2,
 		// Enforce naming of optionally named functions (that could remain anonymous). This helps with debugging, but open to turning this off
 		"func-names": 2,
-		// Enforce a mininmum id length of 2 characters, except i for iterating over loops
+		// Enforce a minimum id length of 2 characters, except i for iterating over loops
 		"id-length": [2, {
 			"exceptions": ["i", "j", "k", "_"]
 		}],

--- a/rules/style.js
+++ b/rules/style.js
@@ -54,7 +54,12 @@ module.exports = {
 		// Enforces maximum nesting level, need to check with team if we want to enforce this
 		"max-depth": [1, 5],
 		// Enforce a maximum line length of 100 characters, while treating tabs as 2 characters
-		"max-len": [1, 100, 2],
+		// Ignore URLs that are longer than 100 characters
+		// Ignore internationalization lines due to long constant names
+		"max-len": [1, 100, 2, {
+			"ignoreUrls": true,
+			"ignorePattern": ".*(FormattedMessage {\\.\\.\\.messages\\.).*|.*(intl\\.formatMessage\\(messages\\.).*"
+		}],
 		// Enforce a maximum of 10 levels of nested callbacks
 		"max-nested-callbacks": 2,
 		// Enforce a maximum of 5 arguments a function can accept

--- a/rules/style.js
+++ b/rules/style.js
@@ -27,7 +27,7 @@ module.exports = {
 		"func-names": 2,
 		// Enforce a mininmum id length of 2 characters, except i for iterating over loops
 		"id-length": [2, {
-			"exceptions": ["i", "j", "_"]
+			"exceptions": ["i", "j", "k", "_"]
 		}],
 		// Enforce tabs equivalent to two spaces
 		"indent": [2, "tab"],


### PR DESCRIPTION
## Description

Update ESLINT rules to remove rules that are not adding value, add a new rule that is missing, and update rules to be more helpful.

- BREAKING: Added `react/jsx-indent` rule to enforce tabbing logical expressions inside a JSX statement.
- UPDATED: Update `max-len` rule to:
  - Ignore URLs since these shouldn't have newlines inside them
  - Ignore internationalization due to long contant names
- UPDATED: Increase `complexity` allowed to the eslint default of `20` as existing rule was unnecessarily constraining
- UPDATED: Remove react rule to start functions with handle
- UPDATED: Update rule `id-length` to allow variables `j` and `k` which are commonly used in `for` loops

Closes #19 
Closes #20 

[Design document](https://paper.dropbox.com/doc/ES-Lint-Clean-Up--BjUe9VTCFUb_xwOrYUOg0ocdAg-GAMTB29WT553cEJvwTWtu)