### PR TITLE
Fix max-len rule to not show warnings when internationalizations have line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Second, when you extend the `.estlintrc` file, you will have to suffix the exten
 
 ## Changelog
 
+- **3.0.1**
+	- UPDATED: Update `max-len` rule to account for line breaks in international regex exceptions.
 - **3.0.0**
 	- BREAKING: Added `react/jsx-indent` rule to enforce tabbing logical expressions inside a JSX statement.
 	- UPDATED: Update `max-len` rule to:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-config-techchange",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techchange",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "repository": {
@@ -18,18 +18,18 @@
   "author": {
     "name": "Will Chester",
     "email": "will@techchange.org",
-    "url": "techchange.org"
+    "url": "https://techchange.org"
   },
   "contributors": [
     {
       "name": "Will Chester",
       "email": "will@techchange.org",
-      "url": "techchange.org"
+      "url": "https://techchange.org"
     },
     {
       "name": "Matthew Heck",
       "email": "matthew@techchange.org",
-      "url": "techchange.org"
+      "url": "https://techchange.org"
     },
     {
       "name": "Gabe Isman",

--- a/rules/style.js
+++ b/rules/style.js
@@ -58,7 +58,7 @@ module.exports = {
 		// Ignore internationalization lines due to long constant names
 		"max-len": [1, 100, 2, {
 			"ignoreUrls": true,
-			"ignorePattern": ".*(FormattedMessage {\\.\\.\\.messages\\.).*|.*(intl\\.formatMessage\\(messages\\.).*"
+			"ignorePattern": ".*({\\.\\.\\.messages\\.).*|.*(intl\\.formatMessage\\(messages\\.).*"
 		}],
 		// Enforce a maximum of 10 levels of nested callbacks
 		"max-nested-callbacks": 2,


### PR DESCRIPTION
Update regex exception in `max-len` rule to prevent warnings for internationalized components even if there are line breaks.

This case was showing a warning when it should not.

![image](https://user-images.githubusercontent.com/71611913/176526884-37fc1f73-7db3-48b5-b7c0-483936785eea.png)

Removed the `FormattedMessage` portion of the regex since the `{...messages` should be sufficient.