### PR TITLE
update max-len rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- **4.2.1**
+	- UPDATED: Ignore `@property` JSDocs tag for `max-len` rule.
 - **4.2.0**
 	- UPDATED: Added new dependency `eslint-plugin-import`.
 	- UPDATED: Added new rules to manage consistent ordering of import statements for both default and react eslint configurations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-techchange",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-techchange",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.27.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-techchange",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "TechChange's default ESLint configurations for ES2015 and React.",
   "main": "index.js",
   "engines": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -59,7 +59,7 @@ module.exports = {
 		// Ignore API docstrings
 		"max-len": [1, 100, 2, {
 			"ignoreUrls": true,
-			"ignorePattern": ".*(\\{\\.\\.\\.messages\\..*\\}).*|.*(intl\\.formatMessage\\(messages\\.).*|(\\s\\*\\s@api).*"
+			"ignorePattern": ".*(\\{\\.\\.\\.messages\\..*\\}).*|.*(intl\\.formatMessage\\(messages\\.).*|(\\s\\*\\s@api|@property).*"
 		}],
 		// Enforce a maximum of 10 levels of nested callbacks
 		"max-nested-callbacks": 2,


### PR DESCRIPTION
## Description
This PR updates the `max-len` style rule to ignore lines beginning with ` * @property` tags for JSDocs.